### PR TITLE
feat:shift recalibrate modal to left of screen in postCalibration

### DIFF
--- a/src/views/PostCalibration.vue
+++ b/src/views/PostCalibration.vue
@@ -263,4 +263,11 @@ export default {
   width: 100%; /* Set the width to whatever you need */
   overflow-x: auto; /* Enable horizontal scrolling */
 }
+.v-dialog__content{
+        flex-direction: column;
+        flex-wrap: nowrap;
+        justify-content: center;
+        align-items: unset;
+        width: max-content;
+    }
 </style>


### PR DESCRIPTION
Related Issue: #36 
I've shifted the modal to the left side of the screen, allowing more data visibility on the page.

![image](https://github.com/ruxailab/web-eye-tracker-front/assets/63046396/d1ceb462-ee25-4de0-89fa-cb6cc8eb53a4)
