### PR TITLE
Changed the configWebCam of DoubleCalibrationRecord.vue

### DIFF
--- a/src/views/DoubleCalibrationRecord.vue
+++ b/src/views/DoubleCalibrationRecord.vue
@@ -39,7 +39,9 @@
 </template>
 
 <script>
+
 export default {
+  
   data() {
     return {
       // camera
@@ -47,12 +49,15 @@ export default {
       recordWebCam: null,
       configWebCam: {
         audio: false,
-        video: {
-          width: 1536,
-          height: 864,
+        video: { /*The fixed values earlier were {1536,864}.
+                 These values got the resolution of a 1080p webcam. 
+                 However, this doesn't work on lower/higher resolution cameras.
+                 Changed it to get the videoWidth and videoHeight of the video stream of the user.*/
+          width: document.getElementById("video-tag").videoWidth,
+          height: document.getElementById("video-tag").videoHeight,
         },
       },
-
+      
       // cablibration
       circleIrisPoints: [],
       calibPredictionPoints: [],
@@ -308,6 +313,7 @@ export default {
     // canvas related
     async startWebCamCapture() {
       // Request permission for screen capture
+
       return navigator.mediaDevices
         .getUserMedia(this.configWebCam)
         .then(async (mediaStreamObj) => {
@@ -315,6 +321,7 @@ export default {
           this.recordWebCam = new MediaRecorder(mediaStreamObj, {
             mimeType: "video/webm;",
           });
+          
           let recordingWebCam = [];
           let video = document.getElementById("video-tag");
           video.srcObject = mediaStreamObj;
@@ -325,6 +332,7 @@ export default {
           };
           // OnStop WebCam Record
           const th = this;
+          
           this.recordWebCam.onstop = () => {
             // Generate blob from the frames
             let blob = new Blob(recordingWebCam, { type: "video/webm" });
@@ -344,7 +352,7 @@ export default {
         })
         .catch((e) => {
           console.error("Error", e);
-          this.stopRecord();
+          //this.stopRecord();
         });
     },
     async detectFace() {

--- a/src/views/DoubleCalibrationRecord.vue
+++ b/src/views/DoubleCalibrationRecord.vue
@@ -49,10 +49,7 @@ export default {
       recordWebCam: null,
       configWebCam: {
         audio: false,
-        video: { /*The fixed values earlier were {1536,864}.
-                 These values got the resolution of a 1080p webcam. 
-                 However, this doesn't work on lower/higher resolution cameras.
-                 Changed it to get the videoWidth and videoHeight of the video stream of the user.*/
+        video: { 
           width: document.getElementById("video-tag").videoWidth,
           height: document.getElementById("video-tag").videoHeight,
         },
@@ -352,18 +349,20 @@ export default {
         })
         .catch((e) => {
           console.error("Error", e);
-          //this.stopRecord();
         });
     },
+
     async detectFace() {
       const lastPrediction = await this.model.estimateFaces({
         input: document.getElementById("video-tag"),
       });
       return lastPrediction
     },
+
     stopRecord() {
       this.recordWebCam.state != "inactive" ? this.stopWebCamCapture() : null;
     },
+
     async stopWebCamCapture() {
       await this.recordWebCam.stop();
       this.calibFinished = true;


### PR DESCRIPTION
Previously, DoubleCalibration.vue used static values for the width and height: {1536,864} which has been changed to dynamically get the video width and length so laptops/computers with webcams with resolution < 1080p can still run the program. 