### PR TITLE
feat: add eye icon on the calibration row #56

### DIFF
--- a/src/components/general/CalibTable.vue
+++ b/src/components/general/CalibTable.vue
@@ -9,8 +9,13 @@
     <v-data-table :headers="headers" :items="filteredCalibrations">
       <template v-slot:item="{ item }">
         <tr>
-          <td @click="select(item)" v-for="(header, index) in headers" :key="index">
+          <td v-for="(header, index) in headers" :key="index">
             {{ item[header.value] }}
+          </td>
+          <td>
+            <v-btn icon color="black" @click="select(item)">
+              <v-icon>mdi-eye</v-icon>
+            </v-btn>
           </td>
           <td>
             <v-btn icon color="black" @click="deleteItem(item)">


### PR DESCRIPTION
Added an Eye button for selecting calibrations while disabling normal row clicks to prevent unintended navigation.

![image](https://github.com/user-attachments/assets/4f9d042c-7d31-4536-a269-6cb851dda696)
