### PR TITLE
fix: Calibration Button on the toolbar not working

### DIFF
--- a/src/components/general/Toolbar.vue
+++ b/src/components/general/Toolbar.vue
@@ -4,9 +4,13 @@
       <v-app-bar-title>Eye Lab</v-app-bar-title>
     </div>
     <v-spacer />
-    <v-btn text dark to="/" v-if="$route.name != 'Dashboard'">
-      {{ $route.name != 'Login' ? 'Calibration' : 'Home' }}
+    
+    <!-- Calibration Button -->
+    <v-btn text dark :to="$route.name === 'Login' ? '/' : '/calibration'" v-if="$route.name != 'Dashboard'">
+      {{ $route.name === 'Login' ? 'Home' : 'Calibration' }}
     </v-btn>
+
+    <!-- Login Button -->
     <v-btn
       text
       dark
@@ -16,6 +20,8 @@
       Login
       <v-icon right>mdi-login</v-icon>
     </v-btn>
+
+    <!-- Logout Button -->
     <v-btn text dark v-if="$store.state.auth.user != null" @click="logout()">
       Logout
       <v-icon right>mdi-logout</v-icon>


### PR DESCRIPTION
Fixed the calibration button on the homepage, not it takes us to the calibration page directly.