### PR TITLE
Feat  if the api is not running avoid starting a calibration

### DIFF
--- a/src/components/general/Toolbar.vue
+++ b/src/components/general/Toolbar.vue
@@ -4,13 +4,9 @@
       <v-app-bar-title>Eye Lab</v-app-bar-title>
     </div>
     <v-spacer />
-    
-    <!-- Calibration Button -->
-    <v-btn text dark :to="$route.name === 'Login' ? '/' : '/calibration'" v-if="$route.name != 'Dashboard'">
-      {{ $route.name === 'Login' ? 'Home' : 'Calibration' }}
+    <v-btn text dark to="/" v-if="$route.name != 'Dashboard'">
+      {{ $route.name != 'Login' ? 'Calibration' : 'Home' }}
     </v-btn>
-
-    <!-- Login Button -->
     <v-btn
       text
       dark
@@ -20,8 +16,6 @@
       Login
       <v-icon right>mdi-login</v-icon>
     </v-btn>
-
-    <!-- Logout Button -->
     <v-btn text dark v-if="$store.state.auth.user != null" @click="logout()">
       Logout
       <v-icon right>mdi-logout</v-icon>

--- a/src/components/general/Toolbar.vue
+++ b/src/components/general/Toolbar.vue
@@ -4,9 +4,13 @@
       <v-app-bar-title>Eye Lab</v-app-bar-title>
     </div>
     <v-spacer />
-    <v-btn text dark to="/" v-if="$route.name != 'Dashboard'">
-      {{ $route.name != 'Login' ? 'Calibration' : 'Home' }}
+    
+    <!-- Calibration Button -->
+    <v-btn text dark :to="$route.name === 'Login' ? '/' : '/calibration'" v-if="$route.name != 'Dashboard'">
+      {{ $route.name === 'Login' ? 'Home' : 'Calibration' }}
     </v-btn>
+
+    <!-- Login Button -->
     <v-btn
       text
       dark
@@ -16,6 +20,8 @@
       Login
       <v-icon right>mdi-login</v-icon>
     </v-btn>
+
+    <!-- Logout Button -->
     <v-btn text dark v-if="$store.state.auth.user != null" @click="logout()">
       Logout
       <v-icon right>mdi-logout</v-icon>

--- a/src/views/CalibrationCard.vue
+++ b/src/views/CalibrationCard.vue
@@ -34,15 +34,28 @@
 
 <script>
 import Toolbar from "@/components/general/Toolbar.vue";
+import axios from "axios";
 
 export default {
   components: {
     Toolbar,
   },
   methods: {
-    goToCameraConfig() {
-      this.$router.push("/calibration/configuration");
+    async goToCameraConfig() {
+      try {
+        const res = await axios.get("/api/session/health");
+
+        if (res.status === 200 && res.data.status === "ok") {
+          this.$router.push("/calibration/configuration");
+        } else {
+          alert("API is not ready. Please try again later.");
+        }
+      } catch (err) {
+        alert("Cannot reach backend. Is the API running?");
+      }
     },
+ 
   },
 };
 </script>
+


### PR DESCRIPTION
This PR ensures callibration process cannot be started before the backend API is configured

Changes that were introduced:

-A health check is added before routing to `/calibration/configuration`
-This displays an Alert is the backend is not available.